### PR TITLE
Fixes zoom regex

### DIFF
--- a/minimapcontrol.lua
+++ b/minimapcontrol.lua
@@ -1,6 +1,6 @@
 addon.name      = 'minimapcontrol'
 addon.author    = 'onimitch'
-addon.version   = '1.2.2'
+addon.version   = '1.2.3'
 addon.desc      = 'Controls the visiblity of the Ashita v4 minimap plugin. Based on atom0s minimapmon with extra functionality.'
 addon.link      = 'https://github.com/onimitch/ffxi-ashita-minimapcontrol'
 

--- a/minimapcontrol.lua
+++ b/minimapcontrol.lua
@@ -303,7 +303,7 @@ minimapcontrol.record_zoom_level = function()
     end
 
     for line in f:lines() do
-        local _, _, zoom_level = string.find(line, 'zoom[%s]*=[%s]*([%d%,]+)')
+        local _, _, zoom_level = string.find(line, 'zoom[%s]*=[%s]*([%d%.,]+)')
         if zoom_level ~= nil then
             minimapcontrol.settings.zoom[minimapcontrol.zone_id] = zoom_level
             settings.save()

--- a/minimapcontrol.lua
+++ b/minimapcontrol.lua
@@ -303,7 +303,7 @@ minimapcontrol.record_zoom_level = function()
     end
 
     for line in f:lines() do
-        local _, _, zoom_level = string.find(line, 'zoom[%s]*=[%s]*([%d%.]+)')
+        local _, _, zoom_level = string.find(line, 'zoom[%s]*=[%s]*([%d%,]+)')
         if zoom_level ~= nil then
             minimapcontrol.settings.zoom[minimapcontrol.zone_id] = zoom_level
             settings.save()


### PR DESCRIPTION
Was minimap plugin updated?

In my minimap.ini file, the zoom value uses a comma, not a dot. Even if you try to edit the value inside minimap's UI config and put a dot, it turns it into a comma (imgui inputfloat behaviour?), also /minimap zoom command doesn't accept dots, only commas. Using a dot simply takes 1 or 0 into account, not the rest.